### PR TITLE
feat(functions.lua): add ESX.GetJob(jobName, key?) function to retrie…

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -561,16 +561,10 @@ function ESX.GetJobs()
     return ESX.Jobs
 end
 
----@param jobName string
----@return table|nil
-function ESX.GetJob(jobName)
+---@return table
+function ESX.GetJob(jobName, key)
     local job = ESX.Jobs[jobName]
-    if job then
-        return job
-    else
-        print(("[^3WARNING^7] Attempting to get invalid job: ^5%s^7"):format(jobName))
-        return nil
-    end
+    return key and job and job[key] or job
 end
 
 ---@return table


### PR DESCRIPTION
…ve job data by name

Adds a new function `ESX.GetJob(jobName, key?)` that returns the full job data or a specific property for a given job name from the `ESX.Jobs` table.

If the job name is invalid or not found, the function returns `nil`.

This provides a simple and efficient way to access job metadata by name, with optional direct access to specific properties.

---

### Description  
Adds a utility function to retrieve a single job's full data or a specific field using its name.

---

### Motivation  
To provide a cleaner, more performant, and consistent way to access job data—especially in cases where only one specific job or property is needed.

---

### Implementation Details  
- Looks up the job in `ESX.Jobs` by key.  
- If a second argument is provided, returns only that specific property if available.  
- If the job is not found, returns `nil` without logging any warnings (to avoid console spam).

---

### Usage Examples
```lua
-- Get full job data
local job = ESX.GetJob("police")
if job then
    print(job.name, job.label)
end

-- Get only the label of a job
local jobLabel = ESX.GetJob("police", "label")
print(jobLabel) -- e.g., "LSPD"
```


### PR Checklist
- []  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- []  My changes have been tested locally and function as expected.
- []  My PR does not introduce any breaking changes.
- []  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
