### PR TITLE
feat(es_extended): Add isNew state to Player stateBag on playerLoaded

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -337,7 +337,9 @@ AddEventHandler("esx:playerLoaded", function(_, xPlayer, isNew)
 
     Core.JobsPlayerCount[job] = (Core.JobsPlayerCount[job] or 0) + 1
     GlobalState[jobKey] = Core.JobsPlayerCount[job]
-    Player(xPlayer.source).state:set('isNew', isNew, false)
+    if isNew then
+        Player(xPlayer.source).state:set('isNew', true, false)
+    end
 end)
 
 AddEventHandler("esx:setJob", function(_, job, lastJob)

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -331,12 +331,13 @@ AddEventHandler("playerDropped", function(reason)
     end
 end)
 
-AddEventHandler("esx:playerLoaded", function(_, xPlayer)
+AddEventHandler("esx:playerLoaded", function(_, xPlayer, isNew)
     local job = xPlayer.getJob().name
     local jobKey = ("%s:count"):format(job)
 
     Core.JobsPlayerCount[job] = (Core.JobsPlayerCount[job] or 0) + 1
     GlobalState[jobKey] = Core.JobsPlayerCount[job]
+    Player(xPlayer.source).state:set('isNew', isNew, true)
 end)
 
 AddEventHandler("esx:setJob", function(_, job, lastJob)

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -337,7 +337,7 @@ AddEventHandler("esx:playerLoaded", function(_, xPlayer, isNew)
 
     Core.JobsPlayerCount[job] = (Core.JobsPlayerCount[job] or 0) + 1
     GlobalState[jobKey] = Core.JobsPlayerCount[job]
-    Player(xPlayer.source).state:set('isNew', isNew, true)
+    Player(xPlayer.source).state:set('isNew', isNew, false)
 end)
 
 AddEventHandler("esx:setJob", function(_, job, lastJob)


### PR DESCRIPTION
Stores the isNew flag in the player's stateBag on server.  On the client, you can get it like this:
```
 print(Player(source).state.isNew)
```

### PR Checklist

- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
